### PR TITLE
This is a sub package to the klevu-smart-search-M2 repository.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "klevu/module-addtocart",
     "description": "Search that learns, generates sales. Fastest, most advanced cloud-based search, autocomplete, instant search",
     "require": {
-		"php": "~5.5.0|~5.6.0|~7.0.0|~7.1.0|~7.2.0|~7.3.0|~7.4.0",
+		"php": "~5.6.0|~7.0.0|~7.1.0|~7.2.0|~7.3.0|~7.4.0|~8.0.0|~8.1.0",
 		"magento/module-store": "@stable",
 		"magento/module-catalog": "@stable",
 		"magento/module-backend": "@stable",
@@ -10,7 +10,7 @@
 		"magento/framework": "@stable"
     },
     "type": "magento-module",
-    "version": "2.5.0",
+    "version": "2.6.0",
     "license": [
         "OSL-3.0",
         "AFL-3.0"


### PR DESCRIPTION
It is for allowing the add-to-cart functionality right from the search results page.
Please, see klevu-smart-search-M2/README.md for more information on how to install the overall extension.