### PR TITLE
This is a sub package to the klevu-smart-search-M2 repository.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,10 +8,10 @@
 		"magento/module-backend": "@stable",
 		"magento/module-eav": "@stable",
 		"magento/framework": "@stable",
-        "klevu/module-productsearch": "^2.7.0"
+        "klevu/module-productsearch": "^2.8.0"
     },
     "type": "magento-module",
-    "version": "2.7.1",
+    "version": "2.8.0",
     "license": [
         "OSL-3.0",
         "AFL-3.0"

--- a/view/frontend/layout/hyva_default.xml
+++ b/view/frontend/layout/hyva_default.xml
@@ -4,7 +4,7 @@
     <body>
         <referenceBlock name="before.body.end">
             <block class="Klevu\Addtocart\Block\Index"
-                   template="Klevu_Addtocart::klevu/addtocart/index.phtml"
+                   template="Klevu_Addtocart::hyva/klevu/addtocart/index.phtml"
                    name="klevu.addtocart.index"/>
         </referenceBlock>
     </body>

--- a/view/frontend/templates/hyva/klevu/addtocart/index.phtml
+++ b/view/frontend/templates/hyva/klevu/addtocart/index.phtml
@@ -1,0 +1,34 @@
+<?php /** @var $block \Klevu\Addtocart\Block\Index */ ?>
+
+<?php if ($block->isAddtocartEnabled()): ?>
+    <script type="text/javascript">
+        function klevu_addtocart(id, url, qty) {
+            let form = document.createElement("form");
+            form.setAttribute('method', "post");
+            form.setAttribute('action', "<?= $block->escapeUrl($block->getUrl('checkout/cart/add')) ?>");
+
+            let formKey = document.createElement("input"); //input element form_key, hidden
+            formKey.setAttribute('type', "hidden");
+            formKey.setAttribute('name', "form_key");
+            formKey.setAttribute('value', hyva.getFormKey());
+
+            let productId = document.createElement("input"); //input element product, hidden
+            productId.setAttribute('type', "hidden");
+            productId.setAttribute('name', "product");
+            productId.setAttribute('value', id);
+
+            let quantity = document.createElement("input"); //input element qty, hidden
+            quantity.setAttribute('type', "hidden");
+            quantity.setAttribute('name', "qty");
+            quantity.setAttribute('value', qty);
+
+            form.appendChild(formKey);
+            form.appendChild(productId);
+            form.appendChild(quantity);
+
+            document.body.appendChild(form);
+            form.submit();
+            document.body.removeChild(form);
+        }
+    </script>
+<?php endif; ?>

--- a/view/frontend/templates/klevu/addtocart/index.phtml
+++ b/view/frontend/templates/klevu/addtocart/index.phtml
@@ -1,13 +1,21 @@
-<?php if ($block->isAddtocartEnabled()):?>
-<script type="text/javascript">
-    function klevu_addtocart(id,url,qty) {
-            var el = document.createElement("a");         
-            el.setAttribute( "data-post", '{"action":"<?php echo $block->getUrl('checkout/cart/add');?>/product/'+id+'/qty/'+qty+'/","data":{"product":"'+id+'","qty":"'+qty+'"}}');    
-            el.style.width="0px !important";
-            el.style.height="0px !important";
+<?php /** @var $block \Klevu\Addtocart\Block\Index */ ?>
+
+<?php if ($block->isAddtocartEnabled()): ?>
+    <script type="text/javascript">
+        function klevu_addtocart(id, url, qty) {
+            var el = document.createElement("a");
+            el.setAttribute(
+                "data-post",
+                '{' +
+                '"action": "<?= $block->escapeUrl($block->getUrl('checkout/cart/add')) ?>",' +
+                '"data": {"product":"' + id + '", "qty":"' + qty + '"}' +
+                '}'
+            );
+            el.style.width = "0px !important";
+            el.style.height = "0px !important";
             document.body.appendChild(el);
             el.click();
-            document.body.removeChild(el);          
-    }
-</script>
+            document.body.removeChild(el);
+        }
+    </script>
 <?php endif; ?>


### PR DESCRIPTION
It is for allowing the add-to-cart functionality right from the search results page.
Please, see klevu-smart-search-M2/README.md for more information on how to install the overall extension.